### PR TITLE
Prerelease 2 - Options + Transformations

### DIFF
--- a/exclaim/src/data/mod.rs
+++ b/exclaim/src/data/mod.rs
@@ -113,7 +113,7 @@ impl Renderable for Data {
         match self {
             Data::Option(option) => {
                 match option {
-                    Some(value) => format!("Some({})", value.render()),
+                    Some(value) => format!("Some({:?})", value),
                     None => String::from("None"),
                 }
             },

--- a/exclaim/src/data/mod.rs
+++ b/exclaim/src/data/mod.rs
@@ -104,7 +104,22 @@ impl Debug for Data {
             Data::Int(num) => write!(f, "{}", num),
             Data::Uint(num) => write!(f, "{}", num),
             Data::Float(num) => write!(f, "{}", num),
-            Data::Tuple(tuple) => write!(f, "{:?}", tuple),
+            Data::Tuple(tuple) => {
+                let mut render = String::from("(");
+                for data in tuple.iter() {
+                    render.push_str(&format!("{:?}, ", data))
+                }
+
+                // Remove ', ' at end 
+                if tuple.len() > 0 {
+                    render.pop();
+                    render.pop();
+                }
+
+                render.push(')');
+
+                write!(f, "{}", render)
+            },
             Data::Object(object) => write!(f, "{:?}", object),
             Data::Array(array) => write!(f, "{:?}", array),
         }
@@ -126,8 +141,8 @@ impl Renderable for Data {
             Data::Float(num) => num.to_string(),
             Data::Tuple(tuple) => {
                 let mut render = String::from("(");
-                for index in 0..tuple.len() {
-                    render.push_str(&format!("{:?}, ", tuple.get(index).unwrap()))
+                for data in tuple.iter() {
+                    render.push_str(&format!("{:?}, ", data))
                 }
 
                 // Remove ', ' at end 
@@ -139,7 +154,7 @@ impl Renderable for Data {
                 render.push(')');
 
                 render
-            }
+            },
             Data::Object(object) => format!("{:?}", object),
             Data::Array(array) => format!("{:?}", array),
         }

--- a/exclaim/src/data/mod.rs
+++ b/exclaim/src/data/mod.rs
@@ -1,4 +1,7 @@
-use std::collections::HashMap;
+use std::collections::{
+    BTreeMap,
+    HashMap,
+};
 use std::fmt::Debug;
 
 use crate::ast::transforms::Transform;
@@ -20,7 +23,7 @@ pub enum Data {
 
     // Compound Types
     Tuple(Box<[Data]>),
-    Object(HashMap<String, Data>),
+    Object(BTreeMap<String, Data>),
     Array(Vec<Data>),
 
     // Wrapper

--- a/exclaim/src/data/mod.rs
+++ b/exclaim/src/data/mod.rs
@@ -60,21 +60,24 @@ impl Data {
         }
     }
 
-    pub fn get(&self, key: &str) -> Option<&Data> {
+    pub fn get(&self, key: &str) -> Data {
         match self {
             Data::Object(object) => {
                 match object.get(key) {
-                    Some(value) => Some(value),
-                    None => None,
+                    Some(value) => value.clone(),
+                    None => panic!("Can't find key '{}' from the current object.", key),
                 }
             },
             Data::Option(option) => {
                 match option {
-                    Some(value) => value.get(key),
-                    None => None,
+                    Some(object) => {
+                        let value = object.get(key);
+                        Data::Option(Some(Box::new(value)))
+                    }
+                    None => panic!("Can't find key '{}' from the option, because the option is none.", key),
                 }
             }
-            _ => None,
+            _ => panic!("Can't find key '{}' on data that isn't an object.", key),
         }
     }
 }

--- a/exclaim/src/data/mod.rs
+++ b/exclaim/src/data/mod.rs
@@ -25,9 +25,9 @@ pub enum Data {
     Float(f64),
 
     // Compound Types
+    Array(Vec<Data>),
     Tuple(Box<[Data]>),
     Object(BTreeMap<String, Data>),
-    Array(Vec<Data>),
 
     // Wrapper
     Option(Option<Box<Data>>),
@@ -66,8 +66,8 @@ impl Data {
 
     pub fn len(&self) -> usize {
         match self {
-            Data::Tuple(tup) => tup.len(),
             Data::Array(arr) => arr.len(),
+            Data::Tuple(tup) => tup.len(),
             _ => 1,
         }
     }
@@ -98,8 +98,8 @@ impl IntoIterator for Data {
 
     fn into_iter(self) -> Self::IntoIter {
         match self {
-            Data::Tuple(tup) => tup.to_vec().into_iter(),
             Data::Array(arr) => arr.into_iter(),
+            Data::Tuple(tup) => tup.to_vec().into_iter(),
             _ => vec![self].into_iter(),
         }
     }
@@ -113,6 +113,7 @@ impl Debug for Data {
             Data::Int(num) => write!(f, "{}", num),
             Data::Uint(num) => write!(f, "{}", num),
             Data::Float(num) => write!(f, "{}", num),
+            Data::Array(array) => write!(f, "{:?}", array),
             Data::Tuple(tuple) => {
                 let mut render = String::from("(");
                 for data in tuple.iter() {
@@ -130,7 +131,6 @@ impl Debug for Data {
                 write!(f, "{}", render)
             },
             Data::Object(object) => write!(f, "{:?}", object),
-            Data::Array(array) => write!(f, "{:?}", array),
         }
     }
 }
@@ -148,6 +148,7 @@ impl Renderable for Data {
             Data::Int(num) => num.to_string(),
             Data::Uint(num) => num.to_string(),
             Data::Float(num) => num.to_string(),
+            Data::Array(array) => format!("{:?}", array),
             Data::Tuple(tuple) => {
                 let mut render = String::from("(");
                 for data in tuple.iter() {
@@ -165,7 +166,6 @@ impl Renderable for Data {
                 render
             },
             Data::Object(object) => format!("{:?}", object),
-            Data::Array(array) => format!("{:?}", array),
         }
     }
 }

--- a/exclaim/src/data/mod.rs
+++ b/exclaim/src/data/mod.rs
@@ -68,6 +68,12 @@ impl Data {
                     None => None,
                 }
             },
+            Data::Option(option) => {
+                match option {
+                    Some(value) => value.get(key),
+                    None => None,
+                }
+            }
             _ => None,
         }
     }

--- a/exclaim/src/data/mod.rs
+++ b/exclaim/src/data/mod.rs
@@ -5,7 +5,10 @@ use std::collections::{
 use std::fmt::Debug;
 
 use crate::ast::transforms::Transform;
-use crate::tokens::Token;
+use crate::tokens::{ 
+    Token,
+    Number,
+};
 
 pub mod traits;
 use traits::Renderable;
@@ -34,7 +37,13 @@ impl From<Token> for Data {
     fn from(token: Token) -> Self {
         match token {
             Token::StringLiteral(string, _) => Data::String(string),
-            Token::NumberLiteral(number, _) => Data::Uint(number),
+            Token::NumberLiteral(number, _) => {
+                match number {
+                    Number::Uint(uint) => Data::Uint(uint),
+                    Number::Int(int) => Data::Int(int),
+                    Number::Float(float) => Data::Float(float),
+                }
+            },
             _ => panic!("Cannot convert token into Data: {:?}", token),
         }
     }

--- a/exclaim/src/data/mod.rs
+++ b/exclaim/src/data/mod.rs
@@ -12,9 +12,6 @@ use transforms::apply_transform;
 
 #[derive(Clone)]
 pub enum Data {
-    // Wrapper
-    Option(Option<Box<Data>>),
-
     // Scalar
     String(String),
     Int(isize),
@@ -25,6 +22,9 @@ pub enum Data {
     Tuple(Box<[Data]>),
     Object(HashMap<String, Data>),
     Array(Vec<Data>),
+
+    // Wrapper
+    Option(Option<Box<Data>>),
 }
 
 impl From<Token> for Data {

--- a/exclaim/src/data/mod.rs
+++ b/exclaim/src/data/mod.rs
@@ -12,6 +12,9 @@ use transforms::apply_transform;
 
 #[derive(Clone)]
 pub enum Data {
+    // Wrapper
+    Option(Option<Box<Data>>),
+
     // Scalar
     String(String),
     Int(isize),
@@ -87,6 +90,7 @@ impl IntoIterator for Data {
 impl Debug for Data {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Data::Option(option) => write!(f, "\"{:?}\"", option),
             Data::String(string) => write!(f, "\"{}\"", string),
             Data::Int(num) => write!(f, "{}", num),
             Data::Uint(num) => write!(f, "{}", num),
@@ -101,6 +105,12 @@ impl Debug for Data {
 impl Renderable for Data {
     fn render(&self) -> String {
         match self {
+            Data::Option(option) => {
+                match option {
+                    Some(value) => format!("Some({})", value.render()),
+                    None => String::from("None"),
+                }
+            },
             Data::String(s) => s.to_string(),
             Data::Int(num) => num.to_string(),
             Data::Uint(num) => num.to_string(),

--- a/exclaim/src/data/mod.rs
+++ b/exclaim/src/data/mod.rs
@@ -64,16 +64,13 @@ impl Data {
         match self {
             Data::Object(object) => {
                 match object.get(key) {
-                    Some(value) => value.clone(),
-                    None => panic!("Can't find key '{}' from the current object.", key),
+                    Some(value) => Data::Option(Some(Box::new(value.clone()))),
+                    None => Data::Option(None),
                 }
             },
             Data::Option(option) => {
                 match option {
-                    Some(object) => {
-                        let value = object.get(key);
-                        Data::Option(Some(Box::new(value)))
-                    }
+                    Some(object) => object.get(key),
                     None => panic!("Can't find key '{}' from the option, because the option is none.", key),
                 }
             }

--- a/exclaim/src/data/mod.rs
+++ b/exclaim/src/data/mod.rs
@@ -121,7 +121,22 @@ impl Renderable for Data {
             Data::Int(num) => num.to_string(),
             Data::Uint(num) => num.to_string(),
             Data::Float(num) => num.to_string(),
-            Data::Tuple(tuple) => format!("{:?}", tuple),
+            Data::Tuple(tuple) => {
+                let mut render = String::from("(");
+                for index in 0..tuple.len() {
+                    render.push_str(&format!("{:?}, ", tuple.get(index).unwrap()))
+                }
+
+                // Remove ', ' at end 
+                if tuple.len() > 0 {
+                    render.pop();
+                    render.pop();
+                }
+
+                render.push(')');
+
+                render
+            }
             Data::Object(object) => format!("{:?}", object),
             Data::Array(array) => format!("{:?}", array),
         }

--- a/exclaim/src/data/transforms.rs
+++ b/exclaim/src/data/transforms.rs
@@ -10,10 +10,13 @@ pub fn apply_transform(data: Data, transform: &Transform, arguments: Vec<Data>) 
         ("array", 0) => array(data),
         ("chars", 0) => chars(data),
         ("enumerate", 0) => enumerate(data),
+        ("float", 0) => float(data),
+        ("int", 0) => int(data),
         ("lowercase", 0) => lowercase(data),
         ("object", 0) => object(data),
         ("string", 0) => string(data),
         ("tuple", 0) => tuple(data),
+        ("uint", 0) => uint(data),
         ("unwrap", 0) => unwrap(data),
         ("uppercase", 0) => uppercase(data),
         ("get", 1) => get(data, arguments.get(0).unwrap()),
@@ -64,6 +67,26 @@ fn enumerate(data: Data) -> Data {
             Data::Array(enumerated_array)
         },
         _ => panic!("enumerate expects an array as input.")
+    }
+}
+
+fn float(data: Data) -> Data {
+    match data {
+        Data::String(string) => {
+            let number: f64 = string.parse().unwrap();
+            Data::Float(number)
+        }
+        _ => panic!("unimplemented"),
+    }
+}
+
+fn int(data: Data) -> Data {
+    match data {
+        Data::String(string) => {
+            let number: isize = string.parse().unwrap();
+            Data::Int(number)
+        }
+        _ => panic!("unimplemented"),
     }
 }
 
@@ -131,6 +154,16 @@ fn tuple(data: Data) -> Data {
             Data::Tuple(array.into_boxed_slice())
         },
         Data::Option(_) => panic!("Unable to call `tuple` on wrapper types.")
+    }
+}
+
+fn uint(data: Data) -> Data {
+    match data {
+        Data::String(string) => {
+            let number: usize = string.parse().unwrap();
+            Data::Uint(number)
+        }
+        _ => panic!("unimplemented"),
     }
 }
 

--- a/exclaim/src/data/transforms.rs
+++ b/exclaim/src/data/transforms.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::ast::transforms::Transform;
 
 use super::Data;
@@ -66,7 +68,14 @@ fn object(data: Data) -> Data {
         Data::String(_) | Data::Int(_) | Data::Uint(_) | Data::Float(_) => panic!("Unable to call `array` on scalar types."),
         Data::Tuple(_) => panic!("Unimplemented"),
         Data::Object(_) => data,
-        Data::Array(_) => panic!("Unimplemented"),
+        Data::Array(array) => {
+            let mut object = HashMap::with_capacity(array.len());
+            for (index, item) in array.iter().enumerate() {
+                object.insert(index.to_string(), item.clone());
+            }
+
+            Data::Object(object)
+        },
         Data::Option(_) => panic!("Unable to call `object` on wrapper types.")
     }
 }
@@ -142,7 +151,7 @@ fn get(data: Data, key: &Data) -> Data {
         
                     Data::Option(Some(Box::new(tuple[*index].clone())))
                 }
-                _ => panic!("at does not transform the given data: {:?}", data),
+                _ => panic!("get does not transform the given data: {:?}", data),
             }
         }
         _ => panic!("get only takes a string as an argument: {:?}.", key)

--- a/exclaim/src/data/transforms.rs
+++ b/exclaim/src/data/transforms.rs
@@ -8,6 +8,7 @@ pub fn apply_transform(data: Data, transform: &Transform, arguments: Vec<Data>) 
         ("chars", 0) => chars(data),
         ("enumerate", 0) => enumerate(data),
         ("lowercase", 0) => lowercase(data),
+        ("string", 0) => string(data),
         ("unwrap", 0) => unwrap(data),
         ("uppercase", 0) => uppercase(data),
         ("get", 1) => get(data, arguments.get(0).unwrap()),
@@ -44,6 +45,17 @@ fn lowercase(data: Data) -> Data {
     match data {
         Data::String(string) => Data::String(string.to_lowercase()),
         _ => panic!("Cannot transform input to lowercase"),
+    }
+}
+
+fn string(data: Data) -> Data {
+    match data {
+        Data::Uint(number) => {
+            Data::String(number.to_string())
+        }
+        Data::Tuple(_) | Data::Object(_) | Data::Array(_) => panic!("Unable to call `string` on compound types."),
+        Data::Option(_) => panic!("Unable to call `string` on wrapper types."),
+        _ => panic!("Invalid input type for `string`.")
     }
 }
 

--- a/exclaim/src/data/transforms.rs
+++ b/exclaim/src/data/transforms.rs
@@ -21,6 +21,9 @@ pub fn apply_transform(data: Data, transform: &Transform, arguments: Vec<Data>) 
         ("uppercase", 0) => uppercase(data),
         ("get", 1) => get(data, arguments.get(0).unwrap()),
         ("take", 1) => take(data, arguments.get(0).unwrap()),
+
+        // Reserved transformation names
+        ("map", 0) | ("filter", 0) | ("reduce", 0) => panic!("Transformation is reserved."),
         _ => panic!("Transform '{:?}' does not exist.", transform),
     }
 }

--- a/exclaim/src/data/transforms.rs
+++ b/exclaim/src/data/transforms.rs
@@ -96,7 +96,7 @@ fn at(data: Data, index: &Data) -> Data {
 fn get(data: Data, key: &Data) -> Data {
     let key = match key {
         Data::String(string) => string,
-        _ => panic!("at only takes a unsigned integer as an argument: {:?}.", key)
+        _ => panic!("get only takes a string as an argument: {:?}.", key)
     };
 
     match data {

--- a/exclaim/src/data/transforms.rs
+++ b/exclaim/src/data/transforms.rs
@@ -72,11 +72,19 @@ fn enumerate(data: Data) -> Data {
 
 fn float(data: Data) -> Data {
     match data {
+        Data::Float(_) => data,
         Data::String(string) => {
             let number: f64 = string.parse().unwrap();
             Data::Float(number)
         }
-        _ => panic!("unimplemented"),
+        Data::Uint(uint) => {
+            Data::Float(uint as f64)
+        }
+        Data::Int(int) => {
+            Data::Float(int as f64)
+        }
+        Data::Array(_) | Data::Tuple(_) | Data::Object(_) => panic!("Unable to call `float` transformation on compound types."),
+        Data::Option(_) => panic!("Unable to call `float` transformation on wrapper types."),
     }
 }
 
@@ -93,7 +101,8 @@ fn int(data: Data) -> Data {
         Data::Float(float) => {
             Data::Int(float as isize)
         }
-        _ => panic!("unimplemented"),
+        Data::Array(_) | Data::Tuple(_) | Data::Object(_) => panic!("Unable to call `int` transformation on compound types."),
+        Data::Option(_) => panic!("Unable to call `int` transformation on wrapper types."),
     }
 }
 
@@ -142,7 +151,6 @@ fn string(data: Data) -> Data {
         }
         Data::Tuple(_) | Data::Object(_) | Data::Array(_) => panic!("Unable to call `string` on compound types."),
         Data::Option(_) => panic!("Unable to call `string` on wrapper types."),
-        _ => panic!("Invalid input type for `string`.")
     }
 }
 
@@ -173,9 +181,22 @@ fn tuple(data: Data) -> Data {
 
 fn uint(data: Data) -> Data {
     match data {
+        Data::Uint(_) => data,
         Data::String(string) => {
             let number: usize = string.parse().unwrap();
             Data::Uint(number)
+        }
+        Data::Int(int) => {
+            if int < 0 {
+                panic!("Unable to transform a negative integer into an unsigned integer")
+            }
+            Data::Uint(int as usize)
+        }
+        Data::Float(float) => {
+            if float < 0.0 {
+                panic!("Unable to transform a negative float into an unsigned integer")
+            }
+            Data::Uint(float as usize)
         }
         _ => panic!("unimplemented"),
     }

--- a/exclaim/src/data/transforms.rs
+++ b/exclaim/src/data/transforms.rs
@@ -5,15 +5,28 @@ use super::Data;
 pub fn apply_transform(data: Data, transform: &Transform, arguments: Vec<Data>) -> Data {
     // match transform signature: (name, num_arguments)
     match transform.signature() {
+        ("array", 0) => array(data),
         ("chars", 0) => chars(data),
         ("enumerate", 0) => enumerate(data),
         ("lowercase", 0) => lowercase(data),
+        ("object", 0) => object(data),
         ("string", 0) => string(data),
+        ("tuple", 0) => tuple(data),
         ("unwrap", 0) => unwrap(data),
         ("uppercase", 0) => uppercase(data),
         ("get", 1) => get(data, arguments.get(0).unwrap()),
         ("take", 1) => take(data, arguments.get(0).unwrap()),
         _ => panic!("Transform '{:?}' does not exist.", transform),
+    }
+}
+
+fn array(data: Data) -> Data {
+    match data {
+        Data::String(_) | Data::Int(_) | Data::Uint(_) | Data::Float(_) => panic!("Unable to call `array` on scalar types."),
+        Data::Tuple(_) => panic!("Unimplemented"),
+        Data::Object(_) => panic!("Unimplemented"),
+        Data::Array(_) => data,
+        Data::Option(_) => panic!("Unable to call `array` on wrapper types.")
     }
 }
 
@@ -48,6 +61,16 @@ fn lowercase(data: Data) -> Data {
     }
 }
 
+fn object(data: Data) -> Data {
+    match data {
+        Data::String(_) | Data::Int(_) | Data::Uint(_) | Data::Float(_) => panic!("Unable to call `array` on scalar types."),
+        Data::Tuple(_) => panic!("Unimplemented"),
+        Data::Object(_) => data,
+        Data::Array(_) => panic!("Unimplemented"),
+        Data::Option(_) => panic!("Unable to call `object` on wrapper types.")
+    }
+}
+
 fn string(data: Data) -> Data {
     match data {
         Data::Uint(number) => {
@@ -56,6 +79,16 @@ fn string(data: Data) -> Data {
         Data::Tuple(_) | Data::Object(_) | Data::Array(_) => panic!("Unable to call `string` on compound types."),
         Data::Option(_) => panic!("Unable to call `string` on wrapper types."),
         _ => panic!("Invalid input type for `string`.")
+    }
+}
+
+fn tuple(data: Data) -> Data {
+    match data {
+        Data::String(_) | Data::Int(_) | Data::Uint(_) | Data::Float(_) => panic!("Unable to call `array` on scalar types."),
+        Data::Tuple(_) => data,
+        Data::Object(_) => panic!("Unimplemented"),
+        Data::Array(_) => panic!("Unimplemented"),
+        Data::Option(_) => panic!("Unable to call `tuple` on wrapper types.")
     }
 }
 

--- a/exclaim/src/data/transforms.rs
+++ b/exclaim/src/data/transforms.rs
@@ -82,9 +82,16 @@ fn float(data: Data) -> Data {
 
 fn int(data: Data) -> Data {
     match data {
+        Data::Int(_) => data,
         Data::String(string) => {
             let number: isize = string.parse().unwrap();
             Data::Int(number)
+        }
+        Data::Uint(uint) => {
+            Data::Int(uint as isize)
+        }
+        Data::Float(float) => {
+            Data::Int(float as isize)
         }
         _ => panic!("unimplemented"),
     }
@@ -123,6 +130,7 @@ fn object(data: Data) -> Data {
 
 fn string(data: Data) -> Data {
     match data {
+        Data::String(_) => data,
         Data::Uint(uint) => {
             Data::String(uint.to_string())
         }

--- a/exclaim/src/data/transforms.rs
+++ b/exclaim/src/data/transforms.rs
@@ -11,26 +11,26 @@ pub fn apply_transform(data: Data, transform: &Transform, arguments: Vec<Data>) 
         "chars" => chars(data),
         "enumerate" => enumerate(data),
         "float" => float(data),
-        "int" => int(data),
-        "lowercase" => lowercase(data),
-        "object" => object(data),
-        "string" => string(data),
-        "tuple" => tuple(data),
-        "uint" => uint(data),
-        "unwrap" => unwrap(data),
-        "uppercase" => uppercase(data),
         "get" => {
             match transform.num_arguments() {
                 1 => get(data, arguments.get(0).unwrap()),
                 _ => panic!("Wrong number of arguments for get"),
             }
         },
+        "int" => int(data),
+        "lowercase" => lowercase(data),
+        "object" => object(data),
+        "string" => string(data),
         "take" => {
             match transform.num_arguments() {
                 1 => take(data, arguments.get(0).unwrap()),
                 _ => panic!("Wrong number of arguments for take"),
             }
         },
+        "tuple" => tuple(data),
+        "uint" => uint(data),
+        "unwrap" => unwrap(data),
+        "uppercase" => uppercase(data),
 
         // Reserved transformation names
         "map" | "filter" | "reduce" => panic!("Transformation is reserved."),

--- a/exclaim/src/data/transforms.rs
+++ b/exclaim/src/data/transforms.rs
@@ -102,8 +102,8 @@ fn get(data: Data, key: &Data) -> Data {
     match data {
         Data::Object(object) => {
             match object.get(key) {
-                Some(value) => value.clone(),
-                None => panic!("The key-value pair does not exist: {:?}", key),
+                Some(value) => Data::Option(Some(Box::new(value.clone()))),
+                None => Data::Option(None),
             }
         },
         _ => panic!("get does not transform the given data: {:?}", data)

--- a/exclaim/src/data/transforms.rs
+++ b/exclaim/src/data/transforms.rs
@@ -6,24 +6,34 @@ use super::Data;
 
 pub fn apply_transform(data: Data, transform: &Transform, arguments: Vec<Data>) -> Data {
     // match transform signature: (name, num_arguments)
-    match transform.signature() {
-        ("array", 0) => array(data),
-        ("chars", 0) => chars(data),
-        ("enumerate", 0) => enumerate(data),
-        ("float", 0) => float(data),
-        ("int", 0) => int(data),
-        ("lowercase", 0) => lowercase(data),
-        ("object", 0) => object(data),
-        ("string", 0) => string(data),
-        ("tuple", 0) => tuple(data),
-        ("uint", 0) => uint(data),
-        ("unwrap", 0) => unwrap(data),
-        ("uppercase", 0) => uppercase(data),
-        ("get", 1) => get(data, arguments.get(0).unwrap()),
-        ("take", 1) => take(data, arguments.get(0).unwrap()),
+    match transform.name() {
+        "array" => array(data),
+        "chars" => chars(data),
+        "enumerate" => enumerate(data),
+        "float" => float(data),
+        "int" => int(data),
+        "lowercase" => lowercase(data),
+        "object" => object(data),
+        "string" => string(data),
+        "tuple" => tuple(data),
+        "uint" => uint(data),
+        "unwrap" => unwrap(data),
+        "uppercase" => uppercase(data),
+        "get" => {
+            match transform.num_arguments() {
+                1 => get(data, arguments.get(0).unwrap()),
+                _ => panic!("Wrong number of arguments for get"),
+            }
+        },
+        "take" => {
+            match transform.num_arguments() {
+                1 => take(data, arguments.get(0).unwrap()),
+                _ => panic!("Wrong number of arguments for take"),
+            }
+        },
 
         // Reserved transformation names
-        ("map", 0) | ("filter", 0) | ("reduce", 0) => panic!("Transformation is reserved."),
+        "map" | "filter" | "reduce" => panic!("Transformation is reserved."),
         _ => panic!("Transform '{:?}' does not exist.", transform),
     }
 }

--- a/exclaim/src/data/transforms.rs
+++ b/exclaim/src/data/transforms.rs
@@ -8,6 +8,7 @@ pub fn apply_transform(data: Data, transform: &Transform, arguments: Vec<Data>) 
         ("chars", 0) => chars(data),
         ("enumerate", 0) => enumerate(data),
         ("lowercase", 0) => lowercase(data),
+        ("unwrap", 0) => unwrap(data),
         ("uppercase", 0) => uppercase(data),
         ("at", 1) => at(data, arguments.get(0).unwrap()),
         ("get", 1) => get(data, arguments.get(0).unwrap()),
@@ -43,24 +44,26 @@ fn enumerate(data: Data) -> Data {
 fn lowercase(data: Data) -> Data {
     match data {
         Data::String(string) => Data::String(string.to_lowercase()),
-        Data::Int(_) => panic!("Cannot transform raw Int to lowercase"),
-        Data::Uint(_) => panic!("Cannot transform raw Uint to lowercase"),
-        Data::Float(_) => panic!("Cannot transform raw Float to lowercase"),
-        Data::Tuple(_) => panic!("Cannot transform raw Tuple to lowercase"),
-        Data::Object(_) => panic!("Cannot transform raw Object to lowercase"),
-        Data::Array(_) => panic!("Cannot transform raw Array to lowercase"),
+        _ => panic!("Cannot transform input to lowercase"),
+    }
+}
+
+fn unwrap(data: Data) -> Data {
+    match data {
+        Data::Option(option) => {
+            match option {
+                Some(value) => *value, // Deref the Box<T>
+                None => panic!("Tried to unwrap nothing!"),
+            }
+        }
+        _ => panic!("unwrap can only transform Options."),
     }
 }
 
 fn uppercase(data: Data) -> Data {
     match data {
         Data::String(string) => Data::String(string.to_uppercase()),
-        Data::Int(_) => panic!("Cannot transform raw Int to uppercase"),
-        Data::Uint(_) => panic!("Cannot transform raw Uint to uppercase"),
-        Data::Float(_) => panic!("Cannot transform raw Float to uppercase"),
-        Data::Tuple(_) => panic!("Cannot transform raw Tuple to uppercase"),
-        Data::Object(_) => panic!("Cannot transform raw Object to uppercase"),
-        Data::Array(_) => panic!("Cannot transform raw Array to uppercase"),
+        _ => panic!("Cannot transform input to uppercase"),
     }
 }
 

--- a/exclaim/src/data/transforms.rs
+++ b/exclaim/src/data/transforms.rs
@@ -28,7 +28,16 @@ fn array(data: Data) -> Data {
         Data::Tuple(tuple) => {
             Data::Array(tuple.to_vec())
         },
-        Data::Object(_) => panic!("Unimplemented"),
+        Data::Object(object) => {
+            let mut array = vec![];
+            for (key, value) in object.into_iter() {
+                let key = Data::String(key);
+                let pair = Data::Tuple(Box::new([key, value]));
+                array.push(pair);
+            }
+
+            Data::Array(array)
+        },
         Data::Array(_) => data,
         Data::Option(_) => panic!("Unable to call `array` on wrapper types.")
     }
@@ -104,7 +113,20 @@ fn tuple(data: Data) -> Data {
     match data {
         Data::String(_) | Data::Int(_) | Data::Uint(_) | Data::Float(_) => panic!("Unable to call `array` on scalar types."),
         Data::Tuple(_) => data,
-        Data::Object(_) => panic!("Unimplemented"),
+        Data::Object(object) => {
+            let mut keys = vec![];
+            let mut values = vec![];
+
+            for (key, value) in object.iter() {
+                keys.push(Data::String(key.to_string()));
+                values.push(value.clone());
+            }
+
+            let keys = Data::Array(keys);
+            let values = Data::Array(values);
+
+            Data::Tuple(Box::new([keys, values]))
+        },
         Data::Array(array) => {
             Data::Tuple(array.into_boxed_slice())
         },

--- a/exclaim/src/data/transforms.rs
+++ b/exclaim/src/data/transforms.rs
@@ -25,7 +25,9 @@ pub fn apply_transform(data: Data, transform: &Transform, arguments: Vec<Data>) 
 fn array(data: Data) -> Data {
     match data {
         Data::String(_) | Data::Int(_) | Data::Uint(_) | Data::Float(_) => panic!("Unable to call `array` on scalar types."),
-        Data::Tuple(_) => panic!("Unimplemented"),
+        Data::Tuple(tuple) => {
+            Data::Array(tuple.to_vec())
+        },
         Data::Object(_) => panic!("Unimplemented"),
         Data::Array(_) => data,
         Data::Option(_) => panic!("Unable to call `array` on wrapper types.")
@@ -66,7 +68,14 @@ fn lowercase(data: Data) -> Data {
 fn object(data: Data) -> Data {
     match data {
         Data::String(_) | Data::Int(_) | Data::Uint(_) | Data::Float(_) => panic!("Unable to call `array` on scalar types."),
-        Data::Tuple(_) => panic!("Unimplemented"),
+        Data::Tuple(tuple) => {
+            let mut object = HashMap::with_capacity(tuple.len());
+            for (index, item) in tuple.iter().enumerate() {
+                object.insert(index.to_string(), item.clone());
+            }
+
+            Data::Object(object)
+        },
         Data::Object(_) => data,
         Data::Array(array) => {
             let mut object = HashMap::with_capacity(array.len());

--- a/exclaim/src/data/transforms.rs
+++ b/exclaim/src/data/transforms.rs
@@ -87,7 +87,9 @@ fn tuple(data: Data) -> Data {
         Data::String(_) | Data::Int(_) | Data::Uint(_) | Data::Float(_) => panic!("Unable to call `array` on scalar types."),
         Data::Tuple(_) => data,
         Data::Object(_) => panic!("Unimplemented"),
-        Data::Array(_) => panic!("Unimplemented"),
+        Data::Array(array) => {
+            Data::Tuple(array.into_boxed_slice())
+        },
         Data::Option(_) => panic!("Unable to call `tuple` on wrapper types.")
     }
 }

--- a/exclaim/src/data/transforms.rs
+++ b/exclaim/src/data/transforms.rs
@@ -123,8 +123,14 @@ fn object(data: Data) -> Data {
 
 fn string(data: Data) -> Data {
     match data {
-        Data::Uint(number) => {
-            Data::String(number.to_string())
+        Data::Uint(uint) => {
+            Data::String(uint.to_string())
+        }
+        Data::Int(int) => {
+            Data::String(int.to_string())
+        }
+        Data::Float(float) => {
+            Data::String(float.to_string())
         }
         Data::Tuple(_) | Data::Object(_) | Data::Array(_) => panic!("Unable to call `string` on compound types."),
         Data::Option(_) => panic!("Unable to call `string` on wrapper types."),

--- a/exclaim/src/data/transforms.rs
+++ b/exclaim/src/data/transforms.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use crate::ast::transforms::Transform;
 
@@ -78,7 +78,7 @@ fn object(data: Data) -> Data {
     match data {
         Data::String(_) | Data::Int(_) | Data::Uint(_) | Data::Float(_) => panic!("Unable to call `array` on scalar types."),
         Data::Tuple(tuple) => {
-            let mut object = HashMap::with_capacity(tuple.len());
+            let mut object = BTreeMap::new();
             for (index, item) in tuple.iter().enumerate() {
                 object.insert(index.to_string(), item.clone());
             }
@@ -87,7 +87,7 @@ fn object(data: Data) -> Data {
         },
         Data::Object(_) => data,
         Data::Array(array) => {
-            let mut object = HashMap::with_capacity(array.len());
+            let mut object = BTreeMap::new();
             for (index, item) in array.iter().enumerate() {
                 object.insert(index.to_string(), item.clone());
             }

--- a/exclaim/src/lexer/tests.rs
+++ b/exclaim/src/lexer/tests.rs
@@ -77,12 +77,63 @@ mod tests {
     }
 
     #[test]
-    fn lexer_block_digit() {
+    fn lexer_block_uint() {
         let input = "{{ 1234 }}";
         let expected = vec![
             Token::Operator(Op::BlockOpen, Location::new(0,0)),
-            Token::NumberLiteral(1234, Location::new(0,3)),
+            Token::NumberLiteral(Number::Uint(1234), Location::new(0,3)),
             Token::Operator(Op::BlockClose, Location::new(0,8)),
+        ];
+
+        let actual = match lexer::run(input) {
+            Ok(tokens) => tokens,
+            Err(e) => panic!(e),
+        };
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn lexer_block_int() {
+        let input = "{{ -1234 }}";
+        let expected = vec![
+            Token::Operator(Op::BlockOpen, Location::new(0,0)),
+            Token::NumberLiteral(Number::Int(-1234), Location::new(0,3)),
+            Token::Operator(Op::BlockClose, Location::new(0,9)),
+        ];
+
+        let actual = match lexer::run(input) {
+            Ok(tokens) => tokens,
+            Err(e) => panic!(e),
+        };
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn lexer_block_float() {
+        let input = "{{ 12.34 }}";
+        let expected = vec![
+            Token::Operator(Op::BlockOpen, Location::new(0,0)),
+            Token::NumberLiteral(Number::Float(12.34), Location::new(0,3)),
+            Token::Operator(Op::BlockClose, Location::new(0,9)),
+        ];
+
+        let actual = match lexer::run(input) {
+            Ok(tokens) => tokens,
+            Err(e) => panic!(e),
+        };
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn lexer_block_negative_float() {
+        let input = "{{ -12.34 }}";
+        let expected = vec![
+            Token::Operator(Op::BlockOpen, Location::new(0,0)),
+            Token::NumberLiteral(Number::Float(-12.34), Location::new(0,3)),
+            Token::Operator(Op::BlockClose, Location::new(0,10)),
         ];
 
         let actual = match lexer::run(input) {
@@ -201,11 +252,11 @@ mod tests {
         let input = "{{ 1 && test && 3 }}";
         let expected = vec![
             Token::Operator(Op::BlockOpen, Location::new(0,0)),
-            Token::NumberLiteral(1, Location::new(0,3)),
+            Token::NumberLiteral(Number::Uint(1), Location::new(0,3)),
             Token::Operator(Op::And, Location::new(0,5)),
             Token::Label(String::from("test"), Location::new(0,8)),
             Token::Operator(Op::And, Location::new(0,13)),
-            Token::NumberLiteral(3, Location::new(0,16)),
+            Token::NumberLiteral(Number::Uint(3), Location::new(0,16)),
             Token::Operator(Op::BlockClose, Location::new(0,18)),
         ];
 
@@ -245,7 +296,7 @@ mod tests {
             Token::Operator(Op::Comma, Location::new(0,7)),
             Token::StringLiteral(String::from("test"), Location::new(0,9)),
             Token::Operator(Op::Comma, Location::new(0,15)),
-            Token::NumberLiteral(2, Location::new(0,17)),
+            Token::NumberLiteral(Number::Uint(2), Location::new(0,17)),
             Token::Operator(Op::BlockClose, Location::new(0,19)),
         ];
 
@@ -323,9 +374,9 @@ mod tests {
             Token::Operator(Op::BlockOpen, Location::new(0,0)),
             Token::Label(String::from("falsy"), Location::new(0,3)),
             Token::Operator(Op::Assign, Location::new(0,9)),
-            Token::NumberLiteral(1, Location::new(0,11)),
+            Token::NumberLiteral(Number::Uint(1), Location::new(0,11)),
             Token::Operator(Op::Equality, Location::new(0,13)),
-            Token::NumberLiteral(2, Location::new(0,16)),
+            Token::NumberLiteral(Number::Uint(2), Location::new(0,16)),
             Token::Operator(Op::BlockClose, Location::new(0,18)),
         ];
 
@@ -344,9 +395,9 @@ mod tests {
             Token::Operator(Op::BlockOpen, Location::new(0,0)),
             Token::Label(String::from("truthy"), Location::new(0,3)),
             Token::Operator(Op::Assign, Location::new(0,10)),
-            Token::NumberLiteral(1, Location::new(0,12)),
+            Token::NumberLiteral(Number::Uint(1), Location::new(0,12)),
             Token::Operator(Op::Inequality, Location::new(0,14)),
-            Token::NumberLiteral(2, Location::new(0,17)),
+            Token::NumberLiteral(Number::Uint(2), Location::new(0,17)),
             Token::Operator(Op::BlockClose, Location::new(0,19)),
         ];
 
@@ -363,11 +414,11 @@ mod tests {
         let input = "{{ 1 || test || 3 }}";
         let expected = vec![
             Token::Operator(Op::BlockOpen, Location::new(0,0)),
-            Token::NumberLiteral(1, Location::new(0,3)),
+            Token::NumberLiteral(Number::Uint(1), Location::new(0,3)),
             Token::Operator(Op::Or, Location::new(0,5)),
             Token::Label(String::from("test"),Location::new(0,8)),
             Token::Operator(Op::Or, Location::new(0,13)),
-            Token::NumberLiteral(3, Location::new(0,16)),
+            Token::NumberLiteral(Number::Uint(3), Location::new(0,16)),
             Token::Operator(Op::BlockClose, Location::new(0,18)),
         ];
 
@@ -426,9 +477,9 @@ mod tests {
             Token::Operator(Op::Pipe, Location::new(1,30)),
             Token::Label(String::from("take"), Location::new(1,32)),
             Token::Operator(Op::ParenOpen, Location::new(1,36)),
-            Token::NumberLiteral(1, Location::new(1,37)),
+            Token::NumberLiteral(Number::Uint(1), Location::new(1,37)),
             Token::Operator(Op::Comma, Location::new(1,38)),
-            Token::NumberLiteral(5, Location::new(1,39)),
+            Token::NumberLiteral(Number::Uint(5), Location::new(1,39)),
             Token::Operator(Op::ParenClose, Location::new(1,40)),
             Token::Operator(Op::BlockClose, Location::new(1,42)),
             token_string_literal("\n<li>", (1, 44)),

--- a/exclaim/src/runtime/mod.rs
+++ b/exclaim/src/runtime/mod.rs
@@ -140,10 +140,7 @@ fn run_expression(ast: &mut Ast, runtime: &mut RuntimeContext, expression: AstIn
                 // Not exactly a fan of this and could be avoided with better structures 
                 for ref_idx in 1..references.len() {
                     let key = references.get(ref_idx).unwrap().label().unwrap();
-                    current_reference = match current_reference.get(key) {
-                        Some(value) => value.clone(),
-                        None => panic!("could not find value for the reference: {:?}", key)
-                    };
+                    current_reference = current_reference.get(key);
                 }
 
                 // We clone the data, because all transformation happen out of place

--- a/exclaim/src/runtime/mod.rs
+++ b/exclaim/src/runtime/mod.rs
@@ -141,7 +141,7 @@ fn run_expression(ast: &mut Ast, runtime: &mut RuntimeContext, expression: AstIn
                 for ref_idx in 1..references.len() {
                     let key = references.get(ref_idx).unwrap().label().unwrap();
                     current_reference = match current_reference.get(key) {
-                        Some(value) => value,
+                        Some(value) => value.clone(),
                         None => panic!("could not find value for the reference: {:?}", key)
                     };
                 }

--- a/exclaim/src/runtime/runtime.rs
+++ b/exclaim/src/runtime/runtime.rs
@@ -36,15 +36,16 @@ impl RuntimeContext {
         self.output.push_str(&item.render())
     }
 
-    pub fn get(&self, key: &str) -> &Data {
+    pub fn get(&self, key: &str) -> Data {
         if let Some(data) = self.scope_ctx.get(key) {
-            data
+            // Im curious if its faster to heap allocate here when necessary or keep Box<Data> for values in hashmap
+            Data::Option(Some(Box::new(data.clone())))
         } else {
             // Check global context
             if let Some(data) = self.global_ctx.get(key) {
-                data
+                Data::Option(Some(Box::new(data.clone())))
             } else {
-                panic!("get: Error could not find data with the key '{}'", key);
+                Data::Option(None)
             }
         }
     }

--- a/exclaim/src/runtime/runtime.rs
+++ b/exclaim/src/runtime/runtime.rs
@@ -38,11 +38,13 @@ impl RuntimeContext {
 
     pub fn get(&self, key: &str) -> Data {
         if let Some(data) = self.scope_ctx.get(key) {
-            // Im curious if its faster to heap allocate here when necessary or keep Box<Data> for values in hashmap
-            Data::Option(Some(Box::new(data.clone())))
+            data.clone()
         } else {
             // Check global context
+            // Accessing key-values from global context may or may not exist, but we let the user deal with that since we can't make assumptions of the global data. 
+            // Will be useful in future when data is pulled from data base
             if let Some(data) = self.global_ctx.get(key) {
+                // Im curious if its faster to heap allocate here when necessary or keep Box<Data> for values in hashmap
                 Data::Option(Some(Box::new(data.clone())))
             } else {
                 Data::Option(None)

--- a/exclaim/src/tokens/mod.rs
+++ b/exclaim/src/tokens/mod.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::ast::AstIndex;
 use crate::common::Location;
 use crate::common::serialize::*;
@@ -7,11 +9,47 @@ use crate::data::traits::Renderable;
 #[derive(Debug, PartialEq, Clone)]
 pub enum Token {
     StringLiteral(String, Location),
-    NumberLiteral(usize, Location),
+    NumberLiteral(Number, Location),
 
     Label(String, Location),
     Operator(Op, Location),
     Action(Action, Location),
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum Number {
+    Uint(usize),
+    Int(isize),
+    Float(f64),
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum Action {
+    End,
+    Let, 
+    Render,
+    Write,
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum Op {
+    And,            // &&
+    Assign,         // =
+    BlockClose,     // }}
+    BlockClosePrime,// } Reserved
+    BlockOpen,      // {{
+    BlockOpenPrime, // { Reserved
+    ClosureOpen,    // [ Reserved
+    ClosureClose,   // ] Reserved
+    Comma,          // , 
+    Dot,            // . 
+    Each,           // :
+    Equality,       // ==
+    Inequality,     // !=
+    Or,             // || 
+    ParenOpen,      // (
+    ParenClose,     // )
+    Pipe,           // | (Chain function operations)
 }
 
 impl Token {
@@ -22,7 +60,7 @@ impl Token {
         }
     }
 
-    pub fn number_literal(&self) -> Option<&usize> {
+    pub fn number_literal(&self) -> Option<&Number> {
         match self {
             Token::NumberLiteral(literal, _) => Some(literal),
             _ => None
@@ -95,34 +133,13 @@ impl Renderable for Token {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum Action {
-    End,
-    Let, 
-    Render,
-    Write,
+impl Display for Number {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Number::Uint(uint) => write!(f, "{}", uint),
+            Number::Int(int) => write!(f, "{}", int),
+            Number::Float(float) => write!(f, "{}", float),
+        }
+    }
 }
-
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum Op {
-    And,            // &&
-    Assign,         // =
-    BlockClose,     // }}
-    BlockClosePrime,// } Reserved
-    BlockOpen,      // {{
-    BlockOpenPrime, // { Reserved
-    ClosureOpen,    // [ Reserved
-    ClosureClose,   // ] Reserved
-    Comma,          // , 
-    Dot,            // . 
-    Each,           // :
-    Equality,       // ==
-    Inequality,     // !=
-    Or,             // || 
-    ParenOpen,      // (
-    ParenClose,     // )
-    Pipe,           // | (Chain function operations)
-}
-
-
 

--- a/exclaim/tests/runtime/input/product.html
+++ b/exclaim/tests/runtime/input/product.html
@@ -4,13 +4,13 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ write! page.title }}</title>
+    <title>{{ write! page.title | unwrap }}</title>
 </head>
 <body>
     {{ let! last_customers = customers | unwrap | take(3) }}
 
-    <h1>{{ write! page.header }}</h1>
-    <p>{{ write! page.body }}</p>
+    <h1>{{ write! page.header | unwrap }}</h1>
+    <p>{{ write! page.body | unwrap }}</p>
     
     <h2>Customer Reviews</h2>
     <ul>

--- a/exclaim/tests/runtime/input/product.html
+++ b/exclaim/tests/runtime/input/product.html
@@ -16,8 +16,8 @@
     <ul>
         {{ render! customer : last_customers }}
             <li>
-                <h3>{{ write! customer.name }}</h3>
-                <p>{{ write! customer.review }}</p>
+                <h3>{{ write! customer.name | unwrap }}</h3>
+                <p>{{ write! customer.review | unwrap }}</p>
             </li>
         {{!}}
     </ul>

--- a/exclaim/tests/runtime/input/product.html
+++ b/exclaim/tests/runtime/input/product.html
@@ -7,7 +7,7 @@
     <title>{{ write! page.title }}</title>
 </head>
 <body>
-    {{ let! last_customers = customers | take(3) }}
+    {{ let! last_customers = customers | unwrap | take(3) }}
 
     <h1>{{ write! page.header }}</h1>
     <p>{{ write! page.body }}</p>

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -305,16 +305,31 @@ fn render_uint_to_string() {
 //     pretty_assertions::assert_eq!(&output, expected)
 // }
 
+#[test]
 fn render_string_to_uint() {
-    // TODO
+    let input = r#"A number into uint: {{ write! "2021" | uint }}"#;
+    let expected = r#"A number into uint: 2021"#;
+    
+    let output = exclaim::run(input, None);
+    pretty_assertions::assert_eq!(&output, expected)
 }
 
+#[test]
 fn render_string_to_int() {
-    // TODO
+    let input = r#"A number into int: {{ write! "-2021" | int }}"#;
+    let expected = r#"A number into int: -2021"#;
+    
+    let output = exclaim::run(input, None);
+    pretty_assertions::assert_eq!(&output, expected)
 }  
 
+#[test]
 fn render_string_to_float() {
-    // TODO
+    let input = r#"A number into uint: {{ write! "3.14" | float }}"#;
+    let expected = r#"A number into uint: 3.14"#;
+    
+    let output = exclaim::run(input, None);
+    pretty_assertions::assert_eq!(&output, expected)
 }
 
 

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -171,9 +171,9 @@ fn render_global_number() {
 #[test]
 fn render_object() {
     let input = r#"The object contains:
-name: {{ write! object.name }}
+name: {{ write! object.name | unwrap }}
 lang: {{ write! object | unwrap | get("lang") }}
-version: {{ write! object.version }}
+version: {{ write! object.version | unwrap }}
 "#;
     let expected = r#"The object contains:
 name: exclaim

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -159,7 +159,7 @@ fn render_tuple_indexing() {
 #[test]
 fn render_global_number() {
     let input = r#"The value for x is {{ write! x }}"#;
-    let expected = r#"The value for x is 144"#;
+    let expected = r#"The value for x is Some(144)"#;
 
     let mut data = DataContext::new();
     data.insert("x".to_string(), Data::Uint(144));
@@ -239,7 +239,7 @@ fn render_sample_product() {
 #[test]
 fn render_unicode_alphabetic() {
     let input = r#"The value for Ψ is {{ write! Ψ }}"#;
-    let expected = r#"The value for Ψ is Psi"#;
+    let expected = r#"The value for Ψ is Some(Psi)"#;
 
     let mut data = DataContext::new();
     data.insert("Ψ".to_string(), Data::String("Psi".to_string()));

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -239,7 +239,7 @@ fn render_sample_product() {
 #[test]
 fn render_unicode_alphabetic() {
     let input = r#"The value for Ψ is {{ write! Ψ }}"#;
-    let expected = r#"The value for Ψ is Some(Psi)"#;
+    let expected = r#"The value for Ψ is Some("Psi")"#;
 
     let mut data = DataContext::new();
     data.insert("Ψ".to_string(), Data::String("Psi".to_string()));

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -355,16 +355,52 @@ fn render_tuple_to_array() {
     pretty_assertions::assert_eq!(&output, expected)
 }
 
+#[test]
 fn render_object_to_tuple() {
-    // TODO
+    let input = r#"Account details: {{ let! (keys, values) = account | unwrap | tuple }}{{ write! keys }} | {{ write! values }}"#;
+    let expected = r#"Account details: ["name", "location", "dob"] | ["Earth", "Milky Way Galaxy", "???"]"#;
+
+    let mut data = DataContext::new();
+    let mut object = HashMap::new();
+    object.insert("name".to_string(), Data::String("Earth".to_string()));
+    object.insert("location".to_string(), Data::String("Milky Way Galaxy".to_string()));
+    object.insert("dob".to_string(), Data::String("???".to_string()));
+    data.insert("account".to_string(), Data::Object(object));
+    
+    let output = exclaim::run(input, Some(data));
+    pretty_assertions::assert_eq!(&output, expected)
 }
 
+#[test]
 fn render_object_to_object() {
-    // TODO
+    let input = r#"Account details: {{ let! object = account | unwrap | object }}{{ write! object.location | unwrap }}"#;
+    let expected = r#"Account details: Milky Way Galaxy"#;
+
+    let mut data = DataContext::new();
+    let mut object = HashMap::new();
+    object.insert("name".to_string(), Data::String("Earth".to_string()));
+    object.insert("location".to_string(), Data::String("Milky Way Galaxy".to_string()));
+    object.insert("dob".to_string(), Data::String("???".to_string()));
+    data.insert("account".to_string(), Data::Object(object));
+    
+    let output = exclaim::run(input, Some(data));
+    pretty_assertions::assert_eq!(&output, expected)
 }
 
+#[test]
 fn render_object_to_array() {
-    // TODO
+    let input = r#"Account details: {{ let! array = account | unwrap | array }}{{ write! array }}"#;
+    let expected = r#"Account details: [("name", "Earth"), ("location", "Milky Way Galaxy"), ("dob", "???")]"#;
+
+    let mut data = DataContext::new();
+    let mut object = HashMap::new();
+    object.insert("name".to_string(), Data::String("Earth".to_string()));
+    object.insert("location".to_string(), Data::String("Milky Way Galaxy".to_string()));
+    object.insert("dob".to_string(), Data::String("???".to_string()));
+    data.insert("account".to_string(), Data::Object(object));
+    
+    let output = exclaim::run(input, Some(data));
+    pretty_assertions::assert_eq!(&output, expected)
 }
 
 #[test]

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -514,3 +514,12 @@ fn render_array_to_array() {
     let output = exclaim::run(input, None);
     pretty_assertions::assert_eq!(&output, expected)
 }
+
+#[test]
+fn render_string_length() {
+    let input = r#"The length of {{ write! "ABC" }} is {{ write! "ABC" | len }}."#;
+    let expected = r#"The length of ABC is 3."#;
+    
+    let output = exclaim::run(input, None);
+    pretty_assertions::assert_eq!(&output, expected)
+}

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -284,31 +284,11 @@ fn render_option_unwrapped() {
     pretty_assertions::assert_eq!(&output, expected)
 }
 
-
 // Scalar to Scalar tests
 #[test]
-fn render_uint_to_string() {
-    let input = r#"A number into digits: {{ write! 1234 | string | chars }}"#;
-    let expected = r#"A number into digits: ["1", "2", "3", "4"]"#;
-    
-    let output = exclaim::run(input, None);
-    pretty_assertions::assert_eq!(&output, expected)
-}
-
-// #[test]
-// fn render_float_to_string() {
-//     // TODO add support for floats.
-//     let input = r#"A number into digits: {{ write! 3.14 | string | chars }}"#;
-//     let expected = r#"The value may exist: ["3", ".", "1", "4"] "#;
-    
-//     let output = exclaim::run(input, None);
-//     pretty_assertions::assert_eq!(&output, expected)
-// }
-
-#[test]
 fn render_string_to_uint() {
-    let input = r#"A number into uint: {{ write! "2021" | uint }}"#;
-    let expected = r#"A number into uint: 2021"#;
+    let input = r#"A string into uint: {{ write! "2021" | uint }}"#;
+    let expected = r#"A string into uint: 2021"#;
     
     let output = exclaim::run(input, None);
     pretty_assertions::assert_eq!(&output, expected)
@@ -316,8 +296,8 @@ fn render_string_to_uint() {
 
 #[test]
 fn render_string_to_int() {
-    let input = r#"A number into int: {{ write! "-2021" | int }}"#;
-    let expected = r#"A number into int: -2021"#;
+    let input = r#"A string into int: {{ write! "-2021" | int }}"#;
+    let expected = r#"A string into int: -2021"#;
     
     let output = exclaim::run(input, None);
     pretty_assertions::assert_eq!(&output, expected)
@@ -325,13 +305,98 @@ fn render_string_to_int() {
 
 #[test]
 fn render_string_to_float() {
-    let input = r#"A number into uint: {{ write! "3.14" | float }}"#;
-    let expected = r#"A number into uint: 3.14"#;
+    let input = r#"A string into float: {{ write! "3.14" | float }}"#;
+    let expected = r#"A string into float: 3.14"#;
     
     let output = exclaim::run(input, None);
     pretty_assertions::assert_eq!(&output, expected)
 }
 
+#[test]
+fn render_int_to_string() {
+    // TODO add support for ints.
+    let input = r#"A int into digits: {{ write! -1234 | string | chars }}"#;
+    let expected = r#"A int into digits: ["-", "1", "2", "3", "4"]"#;
+    
+    let output = exclaim::run(input, None);
+    pretty_assertions::assert_eq!(&output, expected)
+}
+
+#[test]
+#[should_panic]
+fn render_int_to_uint() {
+    // TODO add support for ints.
+    let input = r#"A int into uint: {{ write! -1234 | uint }}"#;
+    
+    let output = exclaim::run(input, None);
+}
+
+#[test]
+fn render_int_to_float() {
+    // TODO add support for ints.
+    let input = r#"A int into float: {{ write! -1234 | float }}"#;
+    let expected = r#"A int into float: -1234"#;
+    
+    let output = exclaim::run(input, None);
+    pretty_assertions::assert_eq!(&output, expected)
+}
+
+#[test]
+fn render_uint_to_string() {
+    let input = r#"A uint into digits: {{ write! 1234 | string | chars }}"#;
+    let expected = r#"A uint into digits: ["1", "2", "3", "4"]"#;
+    
+    let output = exclaim::run(input, None);
+    pretty_assertions::assert_eq!(&output, expected)
+}
+
+#[test]
+fn render_uint_to_int() {
+    let input = r#"A uint into int: {{ write! 1234 | int }}"#;
+    let expected = r#"A uint into int: 1234"#;
+    
+    let output = exclaim::run(input, None);
+    pretty_assertions::assert_eq!(&output, expected)
+}
+
+#[test]
+fn render_uint_to_float() {
+    let input = r#"A uint into float: {{ write! 1234 | float }}"#;
+    let expected = r#"A uint into float: 1234"#;
+    
+    let output = exclaim::run(input, None);
+    pretty_assertions::assert_eq!(&output, expected)
+}
+
+#[test]
+fn render_float_to_string() {
+    // TODO add support for floats.
+    let input = r#"A float into digits: {{ write! 3.14 | string | chars }}"#;
+    let expected = r#"A float into digits: ["3", ".", "1", "4"]"#;
+    
+    let output = exclaim::run(input, None);
+    pretty_assertions::assert_eq!(&output, expected)
+}
+
+#[test]
+fn render_float_to_int() {
+    // TODO add support for floats.
+    let input = r#"A float into int: {{ write! -3.14 | int }}"#;
+    let expected = r#"A float into int: -3"#;
+    
+    let output = exclaim::run(input, None);
+    pretty_assertions::assert_eq!(&output, expected)
+}
+
+#[test]
+fn render_float_to_uint() {
+    // TODO add support for floats.
+    let input = r#"A float into uint: {{ write! 3.14 | uint }}"#;
+    let expected = r#"A float into uint: 3"#;
+    
+    let output = exclaim::run(input, None);
+    pretty_assertions::assert_eq!(&output, expected)
+}
 
 // Compound to Compound tests
 #[test]

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -280,3 +280,89 @@ fn render_option_unwrapped() {
     let output = exclaim::run(input, Some(data));
     pretty_assertions::assert_eq!(&output, expected)
 }
+
+
+// Scalar to Scalar tests
+#[test]
+fn render_uint_to_string() {
+    let input = r#"A number into digits: {{ write! 1234 | string | chars }}"#;
+    let expected = r#"The value may exist: ["1", "2", "3", "4"] "#;
+    
+    let output = exclaim::run(input, None);
+    pretty_assertions::assert_eq!(&output, expected)
+}
+
+// #[test]
+// fn render_float_to_string() {
+//     // TODO add support for floats.
+//     let input = r#"A number into digits: {{ write! 3.14 | string | chars }}"#;
+//     let expected = r#"The value may exist: ["3", ".", "1", "4"] "#;
+    
+//     let output = exclaim::run(input, None);
+//     pretty_assertions::assert_eq!(&output, expected)
+// }
+
+fn render_string_to_uint() {
+    // TODO
+}
+
+fn render_string_to_int() {
+    // TODO
+}  
+
+fn render_string_to_float() {
+    // TODO
+}
+
+
+// Compound to Compound tests
+fn render_tuple_to_tuple() {
+    // TODO
+}
+
+fn render_tuple_to_object() {
+    // TODO
+}
+
+fn render_tuple_to_array() {
+    // TODO
+}
+
+fn render_object_to_tuple() {
+    // TODO
+}
+
+fn render_object_to_object() {
+    // TODO
+}
+
+fn render_object_to_array() {
+    // TODO
+}
+
+#[test]
+fn render_array_to_tuple() {
+    let input = r#"A number into digits: {{ write! "ABC" | chars | tuple }}"#;
+    let expected = r#"The value may exist: ("A", "B", "C")"#;
+    
+    let output = exclaim::run(input, None);
+    pretty_assertions::assert_eq!(&output, expected)
+}
+
+#[test]
+fn render_array_to_object() {
+    let input = r#"A number into digits: {{ write! "ABC" | chars | object }}"#;
+    let expected = r#"The value may exist: {"0":"A", "1":"B", "2":"C"}"#;
+    
+    let output = exclaim::run(input, None);
+    pretty_assertions::assert_eq!(&output, expected)
+}
+
+#[test]
+fn render_array_to_array() {
+    let input = r#"A number into digits: {{ write! "ABC" | chars | array }}"#;
+    let expected = r#"The value may exist: ["A", "B", "C"]"#;
+    
+    let output = exclaim::run(input, None);
+    pretty_assertions::assert_eq!(&output, expected)
+}

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -351,8 +351,8 @@ fn render_array_to_tuple() {
 
 #[test]
 fn render_array_to_object() {
-    let input = r#"An array into an object: {{ write! "ABC" | chars | object }}"#;
-    let expected = r#"An array into an object: {"0":"A", "1":"B", "2":"C"}"#;
+    let input = r#"An array into an object: {{ let! object = "ABC" | chars | object }}{{ write! object | get("0") | unwrap }}"#;
+    let expected = r#"An array into an object: A"#;
     
     let output = exclaim::run(input, None);
     pretty_assertions::assert_eq!(&output, expected)

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -1,6 +1,9 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
-use crate::common::{PrettyString, read_file_to_string};
+use crate::common::{
+    PrettyString, 
+    read_file_to_string
+};
 
 use exclaim::{
     DataContext,
@@ -181,7 +184,7 @@ lang: rust
 version: 0.1
 "#;
 
-    let mut object = HashMap::new();
+    let mut object = BTreeMap::new();
     object.insert("name".to_string(), Data::String("exclaim".to_string()));
     object.insert("lang".to_string(), Data::String("rust".to_string()));
     object.insert("version".to_string(), Data::Float(0.1));
@@ -198,7 +201,7 @@ fn render_sample_product() {
     let input = read_file_to_string("./tests/runtime/input/product.html");
     let expected = read_file_to_string("./tests/runtime/output/product.html");
 
-    let mut page = HashMap::new();
+    let mut page = BTreeMap::new();
     page.insert("title".to_string(), Data::String("Awesome Product".to_string()));
     page.insert("header".to_string(), Data::String("Awesome Product: A product".to_string()));
     page.insert("body".to_string(), Data::String("Lorem ipsum dolor sit amet, consectetur adipiscing elit. \
@@ -208,22 +211,22 @@ fn render_sample_product() {
 
     let mut customers = Vec::new();
 
-    let mut customer = HashMap::new();
+    let mut customer = BTreeMap::new();
     customer.insert("name".to_string(), Data::String("John Doe".to_string()));
     customer.insert("review".to_string(), Data::String("Literally 10/10. This product is game changing.".to_string()));
     customers.push(Data::Object(customer));
 
-    let mut customer = HashMap::new();
+    let mut customer = BTreeMap::new();
     customer.insert("name".to_string(), Data::String("Jane Doe".to_string()));
     customer.insert("review".to_string(), Data::String("My husband loves this product!".to_string()));
     customers.push(Data::Object(customer));
 
-    let mut customer = HashMap::new();
+    let mut customer = BTreeMap::new();
     customer.insert("name".to_string(), Data::String("Anonymous".to_string()));
     customer.insert("review".to_string(), Data::String("The product name checks out.".to_string()));
     customers.push(Data::Object(customer));
 
-    let mut customer = HashMap::new();
+    let mut customer = BTreeMap::new();
     customer.insert("name".to_string(), Data::String("Reed Salad".to_string()));
     customer.insert("review".to_string(), Data::String("It's aight".to_string()));
     customers.push(Data::Object(customer));
@@ -361,7 +364,7 @@ fn render_object_to_tuple() {
     let expected = r#"Account details: ["name", "location", "dob"] | ["Earth", "Milky Way Galaxy", "???"]"#;
 
     let mut data = DataContext::new();
-    let mut object = HashMap::new();
+    let mut object = BTreeMap::new();
     object.insert("name".to_string(), Data::String("Earth".to_string()));
     object.insert("location".to_string(), Data::String("Milky Way Galaxy".to_string()));
     object.insert("dob".to_string(), Data::String("???".to_string()));
@@ -377,7 +380,7 @@ fn render_object_to_object() {
     let expected = r#"Account details: Milky Way Galaxy"#;
 
     let mut data = DataContext::new();
-    let mut object = HashMap::new();
+    let mut object = BTreeMap::new();
     object.insert("name".to_string(), Data::String("Earth".to_string()));
     object.insert("location".to_string(), Data::String("Milky Way Galaxy".to_string()));
     object.insert("dob".to_string(), Data::String("???".to_string()));
@@ -393,7 +396,7 @@ fn render_object_to_array() {
     let expected = r#"Account details: [("name", "Earth"), ("location", "Milky Way Galaxy"), ("dob", "???")]"#;
 
     let mut data = DataContext::new();
-    let mut object = HashMap::new();
+    let mut object = BTreeMap::new();
     object.insert("name".to_string(), Data::String("Earth".to_string()));
     object.insert("location".to_string(), Data::String("Milky Way Galaxy".to_string()));
     object.insert("dob".to_string(), Data::String("???".to_string()));

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -286,7 +286,7 @@ fn render_option_unwrapped() {
 #[test]
 fn render_uint_to_string() {
     let input = r#"A number into digits: {{ write! 1234 | string | chars }}"#;
-    let expected = r#"The value may exist: ["1", "2", "3", "4"] "#;
+    let expected = r#"A number into digits: ["1", "2", "3", "4"]"#;
     
     let output = exclaim::run(input, None);
     pretty_assertions::assert_eq!(&output, expected)
@@ -342,8 +342,8 @@ fn render_object_to_array() {
 
 #[test]
 fn render_array_to_tuple() {
-    let input = r#"A number into digits: {{ write! "ABC" | chars | tuple }}"#;
-    let expected = r#"The value may exist: ("A", "B", "C")"#;
+    let input = r#"An array into a tuple: {{ write! "ABC" | chars | tuple }}"#;
+    let expected = r#"An array into tuple: ("A", "B", "C")"#;
     
     let output = exclaim::run(input, None);
     pretty_assertions::assert_eq!(&output, expected)
@@ -351,8 +351,8 @@ fn render_array_to_tuple() {
 
 #[test]
 fn render_array_to_object() {
-    let input = r#"A number into digits: {{ write! "ABC" | chars | object }}"#;
-    let expected = r#"The value may exist: {"0":"A", "1":"B", "2":"C"}"#;
+    let input = r#"An array into an object: {{ write! "ABC" | chars | object }}"#;
+    let expected = r#"An array into object: {"0":"A", "1":"B", "2":"C"}"#;
     
     let output = exclaim::run(input, None);
     pretty_assertions::assert_eq!(&output, expected)
@@ -360,8 +360,8 @@ fn render_array_to_object() {
 
 #[test]
 fn render_array_to_array() {
-    let input = r#"A number into digits: {{ write! "ABC" | chars | array }}"#;
-    let expected = r#"The value may exist: ["A", "B", "C"]"#;
+    let input = r#"An array into an array: {{ write! "ABC" | chars | array }}"#;
+    let expected = r#"An array into an array: ["A", "B", "C"]"#;
     
     let output = exclaim::run(input, None);
     pretty_assertions::assert_eq!(&output, expected)

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -523,3 +523,30 @@ fn render_string_length() {
     let output = exclaim::run(input, None);
     pretty_assertions::assert_eq!(&output, expected)
 }
+
+#[test]
+fn runtime_string_concat_array() {
+    let input = r#"{{ write! "ABCDEFG" | chars | concat }}"#;
+    let expected = r#"ABCDEFG"#;
+    
+    let output = exclaim::run(input, None);
+    pretty_assertions::assert_eq!(&output, expected)
+}
+
+#[test]
+fn runtime_string_concat_argument() {
+    let input = r#"{{ let! name = "Earth" }}{{ write! "Hello, " | concat(name) | concat("!") }}"#;
+    let expected = r#"Hello, Earth!"#;
+    
+    let output = exclaim::run(input, None);
+    pretty_assertions::assert_eq!(&output, expected)
+}
+
+#[test]
+fn runtime_take_upper_lower() {
+    let input = r#"The string {{ write! "ABCDEFG" }} sliced from 2..5: {{ write! "ABCDEFG" | chars | take(2,5) | concat }}"#;
+    let expected = r#"The string ABCDEFG sliced from 2..5: CDE"#;
+    
+    let output = exclaim::run(input, None);
+    pretty_assertions::assert_eq!(&output, expected)
+}

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -326,7 +326,7 @@ fn render_int_to_uint() {
     // yeah...
     let input = r#"A int into uint: {{ write! 1234 | int | uint }}"#;
     
-    let output = exclaim::run(input, None);
+    let _output = exclaim::run(input, None);
 }
 
 #[test]
@@ -334,7 +334,7 @@ fn render_int_to_uint() {
 fn render_negative_int_to_uint() {
     let input = r#"A int into uint: {{ write! -1234 | uint }}"#;
     
-    let output = exclaim::run(input, None);
+    let _output = exclaim::run(input, None);
 }
 
 #[test]

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -343,7 +343,7 @@ fn render_object_to_array() {
 #[test]
 fn render_array_to_tuple() {
     let input = r#"An array into a tuple: {{ write! "ABC" | chars | tuple }}"#;
-    let expected = r#"An array into tuple: ("A", "B", "C")"#;
+    let expected = r#"An array into a tuple: ("A", "B", "C")"#;
     
     let output = exclaim::run(input, None);
     pretty_assertions::assert_eq!(&output, expected)
@@ -352,7 +352,7 @@ fn render_array_to_tuple() {
 #[test]
 fn render_array_to_object() {
     let input = r#"An array into an object: {{ write! "ABC" | chars | object }}"#;
-    let expected = r#"An array into object: {"0":"A", "1":"B", "2":"C"}"#;
+    let expected = r#"An array into an object: {"0":"A", "1":"B", "2":"C"}"#;
     
     let output = exclaim::run(input, None);
     pretty_assertions::assert_eq!(&output, expected)

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -172,7 +172,7 @@ fn render_global_number() {
 fn render_object() {
     let input = r#"The object contains:
 name: {{ write! object.name }}
-lang: {{ write! object | get("lang") }}
+lang: {{ write! object | unwrap | get("lang") }}
 version: {{ write! object.version }}
 "#;
     let expected = r#"The object contains:

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -322,8 +322,16 @@ fn render_int_to_string() {
 }
 
 #[test]
-#[should_panic]
 fn render_int_to_uint() {
+    // yeah...
+    let input = r#"A int into uint: {{ write! 1234 | int | uint }}"#;
+    
+    let output = exclaim::run(input, None);
+}
+
+#[test]
+#[should_panic(expected="Unable to transform a negative integer into an unsigned integer")]
+fn render_negative_int_to_uint() {
     let input = r#"A int into uint: {{ write! -1234 | uint }}"#;
     
     let output = exclaim::run(input, None);

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -172,7 +172,7 @@ fn render_global_number() {
 fn render_object() {
     let input = r#"The object contains:
 name: {{ write! object.name | unwrap }}
-lang: {{ write! object | unwrap | get("lang") }}
+lang: {{ write! object | unwrap | get("lang") | unwrap }}
 version: {{ write! object.version | unwrap }}
 "#;
     let expected = r#"The object contains:

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -247,3 +247,36 @@ fn render_unicode_alphabetic() {
     let output = exclaim::run(input, Some(data));
     pretty_assertions::assert_eq!(&output, expected)
 }
+
+#[test]
+fn render_option_some() {
+    let input = r#"The value may exist: {{ write! data }}"#;
+    let expected = r#"The value may exist: Some("value")"#;
+
+    let mut data = DataContext::new();
+    data.insert("data".to_string(), Data::String("value".to_string()));
+    
+    let output = exclaim::run(input, Some(data));
+    pretty_assertions::assert_eq!(&output, expected)
+}
+
+#[test]
+fn render_option_none() {
+    let input = r#"The value may exist: {{ write! data }}"#;
+    let expected = r#"The value may exist: None"#;
+    
+    let output = exclaim::run(input, None);
+    pretty_assertions::assert_eq!(&output, expected)
+}
+
+#[test]
+fn render_option_unwrapped() {
+    let input = r#"The value may exist: {{ write! data | unwrap }}"#;
+    let expected = r#"The value may exist: value"#;
+
+    let mut data = DataContext::new();
+    data.insert("data".to_string(), Data::String("value".to_string()));
+    
+    let output = exclaim::run(input, Some(data));
+    pretty_assertions::assert_eq!(&output, expected)
+}

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -314,7 +314,6 @@ fn render_string_to_float() {
 
 #[test]
 fn render_int_to_string() {
-    // TODO add support for ints.
     let input = r#"A int into digits: {{ write! -1234 | string | chars }}"#;
     let expected = r#"A int into digits: ["-", "1", "2", "3", "4"]"#;
     
@@ -325,7 +324,6 @@ fn render_int_to_string() {
 #[test]
 #[should_panic]
 fn render_int_to_uint() {
-    // TODO add support for ints.
     let input = r#"A int into uint: {{ write! -1234 | uint }}"#;
     
     let output = exclaim::run(input, None);
@@ -333,7 +331,6 @@ fn render_int_to_uint() {
 
 #[test]
 fn render_int_to_float() {
-    // TODO add support for ints.
     let input = r#"A int into float: {{ write! -1234 | float }}"#;
     let expected = r#"A int into float: -1234"#;
     
@@ -370,7 +367,6 @@ fn render_uint_to_float() {
 
 #[test]
 fn render_float_to_string() {
-    // TODO add support for floats.
     let input = r#"A float into digits: {{ write! 3.14 | string | chars }}"#;
     let expected = r#"A float into digits: ["3", ".", "1", "4"]"#;
     
@@ -380,7 +376,6 @@ fn render_float_to_string() {
 
 #[test]
 fn render_float_to_int() {
-    // TODO add support for floats.
     let input = r#"A float into int: {{ write! -3.14 | int }}"#;
     let expected = r#"A float into int: -3"#;
     
@@ -390,7 +385,6 @@ fn render_float_to_int() {
 
 #[test]
 fn render_float_to_uint() {
-    // TODO add support for floats.
     let input = r#"A float into uint: {{ write! 3.14 | uint }}"#;
     let expected = r#"A float into uint: 3"#;
     

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -361,7 +361,7 @@ fn render_tuple_to_array() {
 #[test]
 fn render_object_to_tuple() {
     let input = r#"Account details: {{ let! (keys, values) = account | unwrap | tuple }}{{ write! keys }} | {{ write! values }}"#;
-    let expected = r#"Account details: ["name", "location", "dob"] | ["Earth", "Milky Way Galaxy", "???"]"#;
+    let expected = r#"Account details: ["dob", "location", "name"] | ["???", "Milky Way Galaxy", "Earth"]"#;
 
     let mut data = DataContext::new();
     let mut object = BTreeMap::new();
@@ -376,8 +376,8 @@ fn render_object_to_tuple() {
 
 #[test]
 fn render_object_to_object() {
-    let input = r#"Account details: {{ let! object = account | unwrap | object }}{{ write! object.location | unwrap }}"#;
-    let expected = r#"Account details: Milky Way Galaxy"#;
+    let input = r#"Account details: {{ write! account | unwrap | object }}"#;
+    let expected = r#"Account details: {"dob": "???", "location": "Milky Way Galaxy", "name": "Earth"}"#;
 
     let mut data = DataContext::new();
     let mut object = BTreeMap::new();
@@ -393,7 +393,7 @@ fn render_object_to_object() {
 #[test]
 fn render_object_to_array() {
     let input = r#"Account details: {{ let! array = account | unwrap | array }}{{ write! array }}"#;
-    let expected = r#"Account details: [("name", "Earth"), ("location", "Milky Way Galaxy"), ("dob", "???")]"#;
+    let expected = r#"Account details: [("dob", "???"), ("location", "Milky Way Galaxy"), ("name", "Earth")]"#;
 
     let mut data = DataContext::new();
     let mut object = BTreeMap::new();
@@ -417,8 +417,8 @@ fn render_array_to_tuple() {
 
 #[test]
 fn render_array_to_object() {
-    let input = r#"An array into an object: {{ let! object = "ABC" | chars | object }}{{ write! object | get("0") | unwrap }}"#;
-    let expected = r#"An array into an object: A"#;
+    let input = r#"An array into an object: {{ write! "ABC" | chars | object }}"#;
+    let expected = r#"An array into an object: {"0": "A", "1": "B", "2": "C"}"#;
     
     let output = exclaim::run(input, None);
     pretty_assertions::assert_eq!(&output, expected)

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -316,16 +316,43 @@ fn render_string_to_float() {
 
 
 // Compound to Compound tests
+#[test]
 fn render_tuple_to_tuple() {
-    // TODO
+    let input = r#"The 2D position is: {{ write! position | unwrap | tuple }}"#;
+    let expected = r#"The 2D position is: (2, 5)"#;
+
+    let mut data = DataContext::new();
+    let position = Box::new([Data::Uint(2), Data::Uint(5)]);
+    data.insert("position".to_string(), Data::Tuple(position));
+    
+    let output = exclaim::run(input, Some(data));
+    pretty_assertions::assert_eq!(&output, expected)
 }
 
+#[test]
 fn render_tuple_to_object() {
-    // TODO
+    let input = r#"The 2D position is: {{ let! object = position | unwrap | object }}{{ write! object | get("0") | unwrap }}, {{ write! object | get("1") | unwrap }}"#;
+    let expected = r#"The 2D position is: 2, 5"#;
+
+    let mut data = DataContext::new();
+    let position = Box::new([Data::Uint(2), Data::Uint(5)]);
+    data.insert("position".to_string(), Data::Tuple(position));
+    
+    let output = exclaim::run(input, Some(data));
+    pretty_assertions::assert_eq!(&output, expected)
 }
 
+#[test]
 fn render_tuple_to_array() {
-    // TODO
+    let input = r#"The 2D position is: {{ write! position | unwrap | array }}"#;
+    let expected = r#"The 2D position is: [2, 5]"#;
+
+    let mut data = DataContext::new();
+    let position = Box::new([Data::Uint(2), Data::Uint(5)]);
+    data.insert("position".to_string(), Data::Tuple(position));
+    
+    let output = exclaim::run(input, Some(data));
+    pretty_assertions::assert_eq!(&output, expected)
 }
 
 fn render_object_to_tuple() {

--- a/exclaim/tests/runtime/mod.rs
+++ b/exclaim/tests/runtime/mod.rs
@@ -86,8 +86,8 @@ fn render_transformed_assignment() {
 
 #[test]
 fn render_transform_argument() {
-    let input = r#"{{ write! "ABCDEFG" | at(2) }}"#;
-    let expected = "C";
+    let input = r#"{{ write! "ABCDEFG" | chars | get(2) }}"#;
+    let expected = "Some(\"C\")";
 
     let output = exclaim::run(input, None);
     assert_eq!(&output, expected)
@@ -141,7 +141,7 @@ fn render_enumerate() {
 #[test]
 fn render_tuple_indexing() {
     let input = r#"{{ render! chars : "ABC" | chars | enumerate }}
-<li>{{ write! chars | at(1) }}: {{ write! chars | at(0) }}</li>
+<li>{{ write! chars | get(1) | unwrap }}: {{ write! chars | get(0) | unwrap }}</li>
 {{!}}"#;
     let expected = r#"
 <li>0: A</li>

--- a/readme.md
+++ b/readme.md
@@ -92,11 +92,11 @@ Here's an example of using a ```let!``` block:
 **Input:**  
 
 ```none
-{{ let! name = "exclaim!" }}
+{{ let! name = "Exclaim!" }}
 This template was compiled with {{ write! name }} 
 ```
 
-As you can see, we assign the string literal expression ```"exclaim!"``` to a variable named ```name```.
+As you can see, we assign the string literal expression ```"Exclaim!"``` to a variable named ```name```.
 We then write the value of the name on the following line, which gives us:  
 
 ```none

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ A declarative/functional template language built with Rust.
 Full Unicode support.  
 Zero dependencies (except for testing).  
 
-## Version: Pre-release 1
+## Version: Pre-release 2
 
 ## Info
 
@@ -229,7 +229,9 @@ Again, that's a lot of whitespaces...
 
 ## Data types
 
-The data types used at runtime are broken into two categories: scalar and compound.
+The data types used at runtime are broken into three categories: scalars, compounds, and wrappers.
+
+### Scalars
 
 Scalar types are simple and only hold one value. The following scalars are:
 
@@ -238,8 +240,18 @@ Scalar types are simple and only hold one value. The following scalars are:
 - Float (f64)
 - String
 
+### Compounds
+
 Compound types hold one or more values. The following compound types are:
 
 - Tuples (N-sized)
 - Arrays
 - Objects
+
+### Wrappers
+
+The following types wrap all of Exclaim's data types, hence the name "wrappers".
+
+#### **Options**
+
+Options are taken straight from Rust. Options describe whether a reference to data contains *some* value or *nothing*. If the option is in the state Some, it contains a value, if not, the state is None.


### PR DESCRIPTION
A new wrapper type, **Option**, has been introduced. It is a barebones version of Option from Rust. 
Options are useful since we cannot guarantee that the references exist in the external (global) data context in templates. 

Signed integers and floats are now natively supported. 

We also added several useful transformations and streamlined transform lookups. 
- Scalar to Scalar transforms
- Compound to Compound transforms
- Unwrap Option
- Concat, Len, 
- Reserved map, filter, reduce


Objects now use BTreeMaps as the internal data structure. 
The reasoning behind this change is because BTreeMaps are ordered by insertion, so testing is easier and better. Also, the use-cases of objects don't clearly favor HashMaps over BTreeMaps or vice-versa regarding performance. I'll have to test, but for now, the improved testing ability takes precedence. 